### PR TITLE
Provides mappings for shortcuts used in MoveLess Mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Below is the DEFAULT dictionary, for reference.
   'UnfoldAboveAndBelowK1': 'h',
   'UnfoldAboveAndBelowK2': 'L',
   'StopMoveLess': 'p',
-  'UndoMoveLess': "\<Esc>"
+  'AbortMoveLess': "\<Esc>"
 }
   
 You can override the shorcuts by substituting this dictionary for your own,

--- a/README.md
+++ b/README.md
@@ -51,6 +51,40 @@ This behavior could also be used for going into the move less mode again and mak
 
 After such an action the folding will be immediately removed. It is only intended to be used for navigation without moving.
 
+## Customizing the navigation shortcuts
+
+The key bindings mentioned above are controlled by the `g:MoveLess#Mappings`
+variable, which is a dictionary of actions and their activation keys.
+
+Below is the DEFAULT dictionary, for reference.
+
+{
+    'FoldDown': 'j',
+    'FoldUp': 'k',
+    'UnfoldDown': 'J',
+    'UnfoldUp': 'K',
+    'FoldUpAndDownK1': 'l',
+    'FoldUpAndDownK2': 'H',
+    'UnfoldUpAndDownK1': 'h',
+    'UnfoldUpAndDownK2': 'L',
+    'StopMoveLess': 'p',
+    'UndoMoveLess': "\<Esc>"
+}
+  
+To modify any of those shortcuts, simply set the variable in your .vimrc
+with only the keys you want to override. Example:
+
+let g:MoveLess#Mappings =
+  \   {
+  \     'FoldDown': 'i',
+  \     'FoldUp': 'o',
+  \     'UnfoldDown': 'I',
+  \     'UnfoldUp': 'O',
+  \     'StopMoveLess': 'L',
+  \     'UndoMoveLess': 'U'
+  \ }
+
+
 ## Scenarios, how this plugin might help you
 ### Faster navigaton without move
 Let's pretend our cursor is in the middle of a huge file (300 lines) lets say line number 150. And then we are searching for a function. But we are not sure about the function name, we are not even sure if it's located inside the current file at all.

--- a/README.md
+++ b/README.md
@@ -71,18 +71,24 @@ Below is the DEFAULT dictionary, for reference.
     'UndoMoveLess': "\<Esc>"
 }
   
-To modify any of those shortcuts, simply set the variable in your .vimrc
-with only the keys you want to override. Example:
+You can override the shorcuts by substituting this dictionary for your own,
+like the example below.
 
 let g:MoveLess#Mappings =
   \   {
-  \     'FoldDown': 'i',
-  \     'FoldUp': 'o',
-  \     'UnfoldDown': 'I',
-  \     'UnfoldUp': 'O',
-  \     'StopMoveLess': 'L',
-  \     'UndoMoveLess': 'U'
-  \ }
+  \     'FoldBelow': 'e',
+  \     'FoldAbove': 'i',
+  \     'UnfoldBelow': 'I',
+  \     'UnfoldAbove': 'E',
+  \     'FoldAboveAndBelowK1': 's',
+  \     'FoldAboveAndBelowK2': 'O',
+  \     'UnfoldAboveAndBelowK1': 'o',
+  \     'UnfoldAboveAndBelowK2': 'S',
+  \     'StopMoveLess': 'p',
+  \     'AbortMoveLess': "\<Esc>"
+  \   }
+
+Note that you need to provide the full dictionary through the `g:MoveLess#Mappings` variable.
 
 
 ## Scenarios, how this plugin might help you

--- a/README.md
+++ b/README.md
@@ -59,16 +59,16 @@ variable, which is a dictionary of actions and their activation keys.
 Below is the DEFAULT dictionary, for reference.
 
 {
-    'FoldDown': 'j',
-    'FoldUp': 'k',
-    'UnfoldDown': 'J',
-    'UnfoldUp': 'K',
-    'FoldUpAndDownK1': 'l',
-    'FoldUpAndDownK2': 'H',
-    'UnfoldUpAndDownK1': 'h',
-    'UnfoldUpAndDownK2': 'L',
-    'StopMoveLess': 'p',
-    'UndoMoveLess': "\<Esc>"
+  'FoldBelow': 'j',
+  'FoldAbove': 'k',
+  'UnfoldBelow': 'J',
+  'UnfoldAbove': 'K',
+  'FoldAboveAndBelowK1': 'l',
+  'FoldAboveAndBelowK2': 'H',
+  'UnfoldAboveAndBelowK1': 'h',
+  'UnfoldAboveAndBelowK2': 'L',
+  'StopMoveLess': 'p',
+  'UndoMoveLess': "\<Esc>"
 }
   
 You can override the shorcuts by substituting this dictionary for your own,

--- a/doc/move-less.txt
+++ b/doc/move-less.txt
@@ -43,7 +43,22 @@ This behavior could also be used for going into the move less mode again and mak
 MAPPINGS
 
 You are able to override the default mappings during MoveLess mode by providing
-a map through g:MoveLess#Mappings. Simply set the variable in your .vimrc, like
+a map through g:MoveLess#Mappings. This below is the DEFAULT map, for reference.
+
+{
+    'FoldDown': 'j',
+    'FoldUp': 'k',
+    'UnfoldDown': 'J',
+    'UnfoldUp': 'K',
+    'FoldUpAndDownK1': 'l',
+    'FoldUpAndDownK2': 'H',
+    'UnfoldUpAndDownK1': 'h',
+    'UnfoldUpAndDownK2': 'L',
+    'StopMoveLess': 'p',
+    'UndoMoveLess': "\<Esc>"
+}
+  
+To modify any of those shortcuts, simply set the variable in your .vimrc, like
 the following example:
 
 let g:MoveLess#Mappings =
@@ -52,10 +67,6 @@ let g:MoveLess#Mappings =
   \     'FoldUp': 'o',
   \     'UnfoldDown': 'I',
   \     'UnfoldUp': 'O',
-  \     'FoldUpAndDownK1': 'h',
-  \     'FoldUpAndDownK2': 'N',
-  \     'UnfoldUpAndDownK1': 'n',
-  \     'UnfoldUpAndDownK2': 'H',
   \     'StopMoveLess': 'p',
   \     'UndoMoveLess': "\<Esc>"
   \ }

--- a/doc/move-less.txt
+++ b/doc/move-less.txt
@@ -57,7 +57,7 @@ Below is the DEFAULT dictionary, for reference.
   'UnfoldAboveAndBelowK1': 'h',
   'UnfoldAboveAndBelowK2': 'L',
   'StopMoveLess': 'p',
-  'UndoMoveLess': "\<Esc>"
+  'AbortMoveLess': "\<Esc>"
 }
   
 You can override the shorcuts by substituting this dictionary for your own,

--- a/doc/move-less.txt
+++ b/doc/move-less.txt
@@ -42,8 +42,8 @@ This behavior could also be used for going into the move less mode again and mak
 
 MAPPINGS
 
-You are able to override the default mappings during MoveLess mode by providing
-a map through g:MoveLess#Mappings. This below is the DEFAULT map, for reference.
+You are able to override the default mappings during MoveLess mode through
+the variable g:MoveLess#Mappings. This below is the DEFAULT dictionary, for reference.
 
 {
     'FoldDown': 'j',
@@ -58,8 +58,8 @@ a map through g:MoveLess#Mappings. This below is the DEFAULT map, for reference.
     'UndoMoveLess': "\<Esc>"
 }
   
-To modify any of those shortcuts, simply set the variable in your .vimrc, like
-the following example:
+To modify any of those shortcuts, simply set the variable in your .vimrc.
+Example:
 
 let g:MoveLess#Mappings =
   \   {

--- a/doc/move-less.txt
+++ b/doc/move-less.txt
@@ -40,36 +40,44 @@ Any other key: Move less mode will directly be ended, but folding will be tempor
 As long as no jump or walk over the folding was taken the fold remains, if the move-less mode is activated again in such a situation it will just continue the last mode (by still using the actual folding). 
 This behavior could also be used for going into the move less mode again and make a clean abort of the mode by typing <esc>.
 
-MAPPINGS
+|MAPPINGS|
 
-You are able to override the default mappings during MoveLess mode through
-the variable g:MoveLess#Mappings. This below is the DEFAULT dictionary, for reference.
+The key bindings mentioned above are controlled by the *g:MoveLess#Mappings*
+variable, which is a dictionary of actions and their activation keys.
+
+Below is the DEFAULT dictionary, for reference.
 
 {
-    'FoldDown': 'j',
-    'FoldUp': 'k',
-    'UnfoldDown': 'J',
-    'UnfoldUp': 'K',
-    'FoldUpAndDownK1': 'l',
-    'FoldUpAndDownK2': 'H',
-    'UnfoldUpAndDownK1': 'h',
-    'UnfoldUpAndDownK2': 'L',
-    'StopMoveLess': 'p',
-    'UndoMoveLess': "\<Esc>"
+  'FoldBelow': 'j',
+  'FoldAbove': 'k',
+  'UnfoldBelow': 'J',
+  'UnfoldAbove': 'K',
+  'FoldAboveAndBelowK1': 'l',
+  'FoldAboveAndBelowK2': 'H',
+  'UnfoldAboveAndBelowK1': 'h',
+  'UnfoldAboveAndBelowK2': 'L',
+  'StopMoveLess': 'p',
+  'UndoMoveLess': "\<Esc>"
 }
   
-To modify any of those shortcuts, simply set the variable in your .vimrc.
-Example:
+You can override the shorcuts by substituting this dictionary for your own,
+like the example below.
 
 let g:MoveLess#Mappings =
   \   {
-  \     'FoldDown': 'i',
-  \     'FoldUp': 'o',
-  \     'UnfoldDown': 'I',
-  \     'UnfoldUp': 'O',
+  \     'FoldBelow': 'e',
+  \     'FoldAbove': 'i',
+  \     'UnfoldBelow': 'I',
+  \     'UnfoldAbove': 'E',
+  \     'FoldAboveAndBelowK1': 's',
+  \     'FoldAboveAndBelowK2': 'O',
+  \     'UnfoldAboveAndBelowK1': 'o',
+  \     'UnfoldAboveAndBelowK2': 'S',
   \     'StopMoveLess': 'p',
-  \     'UndoMoveLess': "\<Esc>"
-  \ }
+  \     'AbortMoveLess': "\<Esc>"
+  \   }
 
-Note that you don't need to provide the whole map, only the entries that you want to
-replace.
+Note that you need to provide the full dictionary through the *g:MoveLess#Mappings* variable.
+
+===============================================================================
+  vim:tw=80:ts=2:sts=2:sw=2:ft=help:norl:

--- a/doc/move-less.txt
+++ b/doc/move-less.txt
@@ -40,3 +40,25 @@ Any other key: Move less mode will directly be ended, but folding will be tempor
 As long as no jump or walk over the folding was taken the fold remains, if the move-less mode is activated again in such a situation it will just continue the last mode (by still using the actual folding). 
 This behavior could also be used for going into the move less mode again and make a clean abort of the mode by typing <esc>.
 
+MAPPINGS
+
+You are able to override the default mappings during MoveLess mode by providing
+a map through g:MoveLess#Mappings. Simply set the variable in your .vimrc, like
+the following example:
+
+let g:MoveLess#Mappings =
+  \   {
+  \     'FoldDown': 'i',
+  \     'FoldUp': 'o',
+  \     'UnfoldDown': 'I',
+  \     'UnfoldUp': 'O',
+  \     'FoldUpAndDownK1': 'h',
+  \     'FoldUpAndDownK2': 'N',
+  \     'UnfoldUpAndDownK1': 'n',
+  \     'UnfoldUpAndDownK2': 'H',
+  \     'StopMoveLess': 'p',
+  \     'UndoMoveLess': "\<Esc>"
+  \ }
+
+Note that you don't need to provide the whole map, only the entries that you want to
+replace.

--- a/doc/tags
+++ b/doc/tags
@@ -1,1 +1,3 @@
+g:MoveLess#Mappings	move-less.txt	/*g:MoveLess#Mappings*
+g:MoveLess#Mappings	move-less.txt	/*g:MoveLess#Mappings*
 move-less	move-less.txt	/*move-less*

--- a/doc/tags
+++ b/doc/tags
@@ -1,0 +1,1 @@
+move-less	move-less.txt	/*move-less*

--- a/plugin/move-less.vim
+++ b/plugin/move-less.vim
@@ -1,21 +1,19 @@
 " If those mappings change, remember to update the documentation!
-let g:MoveLess#Mappings =
-  \ extend(
-  \   {
-  \     'FoldDown': 'j',
-  \     'FoldUp': 'k',
-  \     'UnfoldDown': 'J',
-  \     'UnfoldUp': 'K',
-  \     'FoldUpAndDownK1': 'l',
-  \     'FoldUpAndDownK2': 'H',
-  \     'UnfoldUpAndDownK1': 'h',
-  \     'UnfoldUpAndDownK2': 'L',
-  \     'StopMoveLess': 'p',
-  \     'UndoMoveLess': "\<Esc>"
-  \   },
-  \   get(g:, 'MoveLess#Mappings', {})
+let g:MoveLess#Mappings = get(
+  \  g:,'MoveLess#Mappings',
+  \  {
+  \    'FoldBelow': 'j',
+  \    'FoldAbove': 'k',
+  \    'UnfoldBelow': 'J',
+  \    'UnfoldAbove': 'K',
+  \    'FoldAboveAndBelowK1': 'l',
+  \    'FoldAboveAndBelowK2': 'H',
+  \    'UnfoldAboveAndBelowK1': 'h',
+  \    'UnfoldAboveAndBelowK2': 'L',
+  \    'StopMoveLess': 'p',
+  \    'AbortMoveLess': "\<Esc>"
+  \  }
   \ )
-
 
 function! s:CheckAfterCursorChanges() 
     if exists("b:moveLessCursorPosition") && b:moveLessCursorPosition[1]
@@ -35,7 +33,7 @@ function! s:CheckAfterCursorChanges()
 endfunction
 
 function! MoveLessMode()
-    let l:result = g:MoveLess#Mappings['FoldDown'] 
+    let l:result = g:MoveLess#Mappings['FoldBelow'] 
     if exists("b:moveLessModePermanentEnded") && b:moveLessModePermanentEnded
         if b:moveLessUpCount > 1
             call s:Unfold(1)
@@ -58,14 +56,14 @@ function! MoveLessMode()
     endif
 
     let l:mode = 'initial'
-    while l:result ==? g:MoveLess#Mappings['FoldDown'] || l:result ==? g:MoveLess#Mappings['FoldUp'] || l:result ==? g:MoveLess#Mappings['FoldUpAndDownK1'] || l:result ==? g:MoveLess#Mappings['UnfoldUpAndDownK1']
+    while l:result ==? g:MoveLess#Mappings['FoldBelow'] || l:result ==? g:MoveLess#Mappings['FoldAbove'] || l:result ==? g:MoveLess#Mappings['FoldAboveAndBelowK1'] || l:result ==? g:MoveLess#Mappings['UnfoldAboveAndBelowK1']
         let l:result = ''
         while l:result == ''
             let l:result = nr2char(getchar(1))
             sleep 20m
         endwhile
         
-        if l:result ==? g:MoveLess#Mappings['FoldDown'] || l:result ==? g:MoveLess#Mappings['FoldUp'] || l:result ==? g:MoveLess#Mappings['FoldUpAndDownK1'] || l:result ==? g:MoveLess#Mappings['UnfoldUpAndDownK1'] || l:result ==# g:MoveLess#Mappings['StopMoveLess']
+        if l:result ==? g:MoveLess#Mappings['FoldBelow'] || l:result ==? g:MoveLess#Mappings['FoldAbove'] || l:result ==? g:MoveLess#Mappings['FoldAboveAndBelowK1'] || l:result ==? g:MoveLess#Mappings['UnfoldAboveAndBelowK1'] || l:result ==# g:MoveLess#Mappings['StopMoveLess']
             let l:result = nr2char(getchar())
         endif
 
@@ -73,7 +71,7 @@ function! MoveLessMode()
         let l:firstLine = 1
 
         
-        if l:result ==# g:MoveLess#Mappings['FoldDown']
+        if l:result ==# g:MoveLess#Mappings['FoldBelow']
             if l:mode ==# 'down'
                 if l:endLine - b:moveLessCursorPosition[1] - b:moveLessDownCount > &scroll  
                     let b:moveLessDownCount = s:FoldAndAdjustCount(b:moveLessDownCount, &scroll, 0)
@@ -83,7 +81,7 @@ function! MoveLessMode()
             endif
             exec "normal! zt"
             redraw
-        elseif l:result ==# g:MoveLess#Mappings['UnfoldDown']
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldBelow']
             if l:mode ==# 'down'
                 if b:moveLessDownCount > 0
                     if b:moveLessDownCount > &scroll
@@ -98,7 +96,7 @@ function! MoveLessMode()
             endif
             exec "normal! zt"
             redraw
-        elseif l:result ==# g:MoveLess#Mappings['FoldUp']
+        elseif l:result ==# g:MoveLess#Mappings['FoldAbove']
             if l:mode ==# 'up'
                 if  b:moveLessCursorPosition[1] - l:firstLine - b:moveLessUpCount > &scroll  
                     let b:moveLessUpCount = s:FoldAndAdjustCount(b:moveLessUpCount, &scroll, 1)
@@ -108,7 +106,7 @@ function! MoveLessMode()
             endif
             exec "normal! z-"
             redraw
-        elseif l:result ==# g:MoveLess#Mappings['UnfoldUp']
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldAbove']
             if l:mode ==# 'up'
                 if b:moveLessUpCount > 0
                     if b:moveLessUpCount > &scroll
@@ -123,7 +121,7 @@ function! MoveLessMode()
             endif
             exec "normal! z-"
             redraw
-        elseif l:result ==# g:MoveLess#Mappings['FoldUpAndDownK1'] || l:result ==# g:MoveLess#Mappings['FoldUpAndDownK2']
+        elseif l:result ==# g:MoveLess#Mappings['FoldAboveAndBelowK1'] || l:result ==# g:MoveLess#Mappings['FoldAboveAndBelowK2']
             if l:mode ==# 'both'
                 if l:endLine - b:moveLessCursorPosition[1] - b:moveLessDownCount > &scroll/2  
                     let b:moveLessDownCount = s:FoldAndAdjustCount(b:moveLessDownCount, &scroll/2, 0)
@@ -136,7 +134,7 @@ function! MoveLessMode()
             endif
             exec "normal! z."
             redraw
-        elseif l:result ==# g:MoveLess#Mappings['UnfoldUpAndDownK1'] || l:result ==# g:MoveLess#Mappings['FoldUpAndDownK2']
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldAboveAndBelowK1'] || l:result ==# g:MoveLess#Mappings['FoldAboveAndBelowK2']
             if l:mode ==# 'both'
                 if b:moveLessDownCount > 0
                     if b:moveLessDownCount > &scroll/2
@@ -161,7 +159,7 @@ function! MoveLessMode()
             redraw
         endif
     endwhile
-    if l:result ==# g:MoveLess#Mappings['UndoMoveLess']
+    if l:result ==# g:MoveLess#Mappings['AbortMoveLess']
         if b:moveLessUpCount > 1
             call s:Unfold(1)
         endif

--- a/plugin/move-less.vim
+++ b/plugin/move-less.vim
@@ -1,3 +1,21 @@
+let g:MoveLess#Mappings =
+  \ extend(
+  \   {
+  \     'FoldDown': 'j',
+  \     'FoldUp': 'k',
+  \     'UnfoldDown': 'J',
+  \     'UnfoldUp': 'K',
+  \     'FoldUpAndDownK1': 'l',
+  \     'FoldUpAndDownK2': 'H',
+  \     'UnfoldUpAndDownK1': 'h',
+  \     'UnfoldUpAndDownK2': 'L',
+  \     'StopMoveLess': 'p',
+  \     'UndoMoveLess': "\<Esc>"
+  \   },
+  \   get(g:, 'MoveLess#Mappings', {})
+  \ )
+
+
 function! s:CheckAfterCursorChanges() 
     if exists("b:moveLessCursorPosition") && b:moveLessCursorPosition[1]
         let l:currentLine = line(".")
@@ -16,7 +34,7 @@ function! s:CheckAfterCursorChanges()
 endfunction
 
 function! MoveLessMode()
-    let l:result = 'j' 
+    let l:result = g:MoveLess#Mappings['FoldDown'] 
     if exists("b:moveLessModePermanentEnded") && b:moveLessModePermanentEnded
         if b:moveLessUpCount > 1
             call s:Unfold(1)
@@ -39,14 +57,14 @@ function! MoveLessMode()
     endif
 
     let l:mode = 'initial'
-    while l:result ==? 'j' || l:result ==? 'k' || l:result ==? 'l' || l:result ==? 'h'
+    while l:result ==? g:MoveLess#Mappings['FoldDown'] || l:result ==? g:MoveLess#Mappings['FoldUp'] || l:result ==? g:MoveLess#Mappings['FoldUpAndDownK1'] || l:result ==? g:MoveLess#Mappings['UnfoldUpAndDownK1']
         let l:result = ''
         while l:result == ''
             let l:result = nr2char(getchar(1))
             sleep 20m
         endwhile
         
-        if l:result ==? 'j' || l:result ==? 'k' || l:result ==? 'l' || l:result ==? 'h' || l:result ==# 'p'
+        if l:result ==? g:MoveLess#Mappings['FoldDown'] || l:result ==? g:MoveLess#Mappings['FoldUp'] || l:result ==? g:MoveLess#Mappings['FoldUpAndDownK1'] || l:result ==? g:MoveLess#Mappings['UnfoldUpAndDownK1'] || l:result ==# g:MoveLess#Mappings['StopMoveLess']
             let l:result = nr2char(getchar())
         endif
 
@@ -54,7 +72,7 @@ function! MoveLessMode()
         let l:firstLine = 1
 
         
-        if l:result ==# 'j'
+        if l:result ==# g:MoveLess#Mappings['FoldDown']
             if l:mode ==# 'down'
                 if l:endLine - b:moveLessCursorPosition[1] - b:moveLessDownCount > &scroll  
                     let b:moveLessDownCount = s:FoldAndAdjustCount(b:moveLessDownCount, &scroll, 0)
@@ -64,7 +82,7 @@ function! MoveLessMode()
             endif
             exec "normal! zt"
             redraw
-        elseif l:result ==# 'J'
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldDown']
             if l:mode ==# 'down'
                 if b:moveLessDownCount > 0
                     if b:moveLessDownCount > &scroll
@@ -79,7 +97,7 @@ function! MoveLessMode()
             endif
             exec "normal! zt"
             redraw
-        elseif l:result ==# 'k'
+        elseif l:result ==# g:MoveLess#Mappings['FoldUp']
             if l:mode ==# 'up'
                 if  b:moveLessCursorPosition[1] - l:firstLine - b:moveLessUpCount > &scroll  
                     let b:moveLessUpCount = s:FoldAndAdjustCount(b:moveLessUpCount, &scroll, 1)
@@ -89,7 +107,7 @@ function! MoveLessMode()
             endif
             exec "normal! z-"
             redraw
-        elseif l:result ==# 'K'
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldUp']
             if l:mode ==# 'up'
                 if b:moveLessUpCount > 0
                     if b:moveLessUpCount > &scroll
@@ -104,7 +122,7 @@ function! MoveLessMode()
             endif
             exec "normal! z-"
             redraw
-        elseif l:result ==# 'l' || l:result ==# 'H'
+        elseif l:result ==# g:MoveLess#Mappings['FoldUpAndDownK1'] || l:result ==# g:MoveLess#Mappings['FoldUpAndDownK2']
             if l:mode ==# 'both'
                 if l:endLine - b:moveLessCursorPosition[1] - b:moveLessDownCount > &scroll/2  
                     let b:moveLessDownCount = s:FoldAndAdjustCount(b:moveLessDownCount, &scroll/2, 0)
@@ -117,7 +135,7 @@ function! MoveLessMode()
             endif
             exec "normal! z."
             redraw
-        elseif l:result ==# 'h' || l:result ==# 'L'
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldUpAndDownK1'] || l:result ==# g:MoveLess#Mappings['FoldUpAndDownK2']
             if l:mode ==# 'both'
                 if b:moveLessDownCount > 0
                     if b:moveLessDownCount > &scroll/2
@@ -142,7 +160,7 @@ function! MoveLessMode()
             redraw
         endif
     endwhile
-    if l:result ==# "\<esc>"
+    if l:result ==# g:MoveLess#Mappings['UndoMoveLess']
         if b:moveLessUpCount > 1
             call s:Unfold(1)
         endif
@@ -150,7 +168,7 @@ function! MoveLessMode()
             call s:Unfold(0)
         endif
         unlet b:moveLessCursorPosition
-    elseif l:result ==# "p"
+    elseif l:result ==# g:MoveLess#Mappings['StopMoveLess']
         let b:moveLessModePermanentEnded = 1
         " if p is clicked the folding should be permaent until someone would clear it with move less mode <ESC> or make a new move less mode navigation
     else
@@ -197,4 +215,4 @@ function! s:Unfold(up)
 endfunction
 
 
-noremap <leader>m :call MoveLessMode()<cr>
+silent! noremap <unique> <leader>m :call MoveLessMode()<cr>

--- a/plugin/move-less.vim
+++ b/plugin/move-less.vim
@@ -32,6 +32,10 @@ function! s:CheckAfterCursorChanges()
     endif
 endfunction
 
+function! s:IsFoldKey(key)
+  return a:key ==# g:MoveLess#Mappings['FoldBelow'] || a:key ==# g:MoveLess#Mappings['FoldAbove'] || a:key ==# g:MoveLess#Mappings['FoldAboveAndBelowK1'] || a:key ==# g:MoveLess#Mappings['UnfoldAboveAndBelowK1'] || a:key ==# g:MoveLess#Mappings['FoldAboveAndBelowK2'] || a:key ==# g:MoveLess#Mappings['UnfoldAboveAndBelowK2']
+endfunction
+
 function! MoveLessMode()
     let l:result = g:MoveLess#Mappings['FoldBelow'] 
     if exists("b:moveLessModePermanentEnded") && b:moveLessModePermanentEnded
@@ -56,14 +60,14 @@ function! MoveLessMode()
     endif
 
     let l:mode = 'initial'
-    while l:result ==? g:MoveLess#Mappings['FoldBelow'] || l:result ==? g:MoveLess#Mappings['FoldAbove'] || l:result ==? g:MoveLess#Mappings['FoldAboveAndBelowK1'] || l:result ==? g:MoveLess#Mappings['UnfoldAboveAndBelowK1']
+    while s:IsFoldKey(l:result)
         let l:result = ''
         while l:result == ''
             let l:result = nr2char(getchar(1))
             sleep 20m
         endwhile
         
-        if l:result ==? g:MoveLess#Mappings['FoldBelow'] || l:result ==? g:MoveLess#Mappings['FoldAbove'] || l:result ==? g:MoveLess#Mappings['FoldAboveAndBelowK1'] || l:result ==? g:MoveLess#Mappings['UnfoldAboveAndBelowK1'] || l:result ==# g:MoveLess#Mappings['StopMoveLess']
+        if s:IsFoldKey(l:result) || l:result ==# g:MoveLess#Mappings['StopMoveLess']
             let l:result = nr2char(getchar())
         endif
 
@@ -134,7 +138,7 @@ function! MoveLessMode()
             endif
             exec "normal! z."
             redraw
-        elseif l:result ==# g:MoveLess#Mappings['UnfoldAboveAndBelowK1'] || l:result ==# g:MoveLess#Mappings['FoldAboveAndBelowK2']
+        elseif l:result ==# g:MoveLess#Mappings['UnfoldAboveAndBelowK1'] || l:result ==# g:MoveLess#Mappings['UnfoldAboveAndBelowK2']
             if l:mode ==# 'both'
                 if b:moveLessDownCount > 0
                     if b:moveLessDownCount > &scroll/2

--- a/plugin/move-less.vim
+++ b/plugin/move-less.vim
@@ -1,3 +1,4 @@
+" If those mappings change, remember to update the documentation!
 let g:MoveLess#Mappings =
   \ extend(
   \   {


### PR DESCRIPTION
First of all, thank you for the idea on this plugin.

The changes on this PR introduce flexible bindings instead of hardcoded keys for operation, providing a variable through which users can bind their own keys.

The variable is named g:MoveLess#Mappings and doesn't need to be provided fully (it is extended with the defaults).

---

**Another small change at the bottom of the file:** Prevent suggested shortcut <Leader>m from overriding user map.